### PR TITLE
Updated line 62 for

### DIFF
--- a/demo/model_func.py
+++ b/demo/model_func.py
@@ -59,7 +59,7 @@ class Face_Model(object):
                 print (path)
                 with open (path, 'r') as f:
                     model = model_from_json(f.read())
-                    graph = tf.get_default_graph()
+                    graph = tf.compat.v1.get_default_graph()
             return model, graph
 
     def load_weights(self, model, path, h5 = True):


### PR DESCRIPTION
TensorFlow version update, tf.get_graph is now tf.compat.v1.get_graph - gee
thanks Google for all that backwards compatability